### PR TITLE
Expose imports between templates

### DIFF
--- a/default_theme/index.js
+++ b/default_theme/index.js
@@ -71,21 +71,20 @@ module.exports = function (comments, options, callback) {
       }
     }
   };
+  
+  imports.renderSectionList =  _.template(fs.readFileSync(path.join(__dirname, 'section_list._'), 'utf8'), {
+    imports: imports
+  });
+  imports.renderSection = _.template(fs.readFileSync(path.join(__dirname, 'section._'), 'utf8'), {
+    imports: imports
+  });
+  imports.renderNote = _.template(fs.readFileSync(path.join(__dirname, 'note._'), 'utf8'), {
+    imports: imports
+  });
 
-  var pageTemplate = _.template(
-    fs.readFileSync(path.join(__dirname, 'index._'), 'utf8'), {
-      imports: _.assign({}, sharedImports.imports, {
-        renderSection: _.template(
-          fs.readFileSync(path.join(__dirname, 'section._'), 'utf8'),
-          sharedImports),
-        renderNote: _.template(
-          fs.readFileSync(path.join(__dirname, 'note._'), 'utf8'),
-          sharedImports),
-        renderSectionList: _.template(
-          fs.readFileSync(path.join(__dirname, 'section_list._'), 'utf8'),
-          sharedImports)
-      })
-    });
+  var pageTemplate = _.template(fs.readFileSync(path.join(__dirname, 'index._'), 'utf8'), {
+    imports: imports
+  });
 
   // push assets into the pipeline as well.
   vfs.src([__dirname + '/assets/**'], { base: __dirname })


### PR DESCRIPTION
Exposes `renderSectionList`, and `renderSection` & `renderNote` for consistency. Fixes #462
